### PR TITLE
Add stdout/stderr file redirection to async MPI executor

### DIFF
--- a/ensemble_launcher/ensemble/ensemble.py
+++ b/ensemble_launcher/ensemble/ensemble.py
@@ -38,6 +38,8 @@ class Task(BaseModel):
     end_time: Any = None
     executor_name: Optional[str] = None
     tag: Optional[str] = None
+    stdout_file: Optional[str] = None
+    stderr_file: Optional[str] = None
 
     def get_resource_requirements(self) -> "JobResource":
         """Build JobResource requirements from this Task."""
@@ -177,6 +179,8 @@ class TaskFactory:
                 gpu_affinity=task_dict["gpu_affinity"].split(",")
                 if "gpu_affinity" in task_dict
                 else [],
+                stdout_file=task_dict.get("stdout_file", None),
+                stderr_file=task_dict.get("stderr_file", None),
             )
         return task_objects
 

--- a/ensemble_launcher/executors/async_mpi_executor.py
+++ b/ensemble_launcher/executors/async_mpi_executor.py
@@ -198,6 +198,8 @@ class AsyncMPIExecutor(Executor):
         mpi_kwargs: Dict[str, Any] = {},
         serial_launch: bool = False,
         run_dir: str = os.getcwd(),
+        stdout_file: Optional[str] = None,
+        stderr_file: Optional[str] = None,
     ) -> AsyncFuture:
         # task is a str command
         task_id = str(uuid.uuid4())
@@ -252,6 +254,8 @@ class AsyncMPIExecutor(Executor):
                 nodes=job_resource.nodes,
                 setup_files=setup_files,
                 run_dir=run_dir,
+                stdout_file=stdout_file,
+                stderr_file=stderr_file,
             )
         )
         self._tasks[task_id] = asyncio_task
@@ -298,6 +302,8 @@ class AsyncMPIExecutor(Executor):
         nodes: Optional[List[str]] = None,
         setup_files: Optional[Dict] = None,
         run_dir: Optional[str] = None,
+        stdout_file: Optional[str] = None,
+        stderr_file: Optional[str] = None,
     ):
         if setup_files and setup_files.get("gpu_affinity") and nodes:
             fname = f"/tmp/gpu_affinity_file_{task_id}.sh"
@@ -306,45 +312,65 @@ class AsyncMPIExecutor(Executor):
             )
         self.logger.info(f"executing: {' '.join(cmd)}")
 
-        # We separate the executable from the arguments
         program = cmd[0]
         args = cmd[1:]
 
-        if self._return_stdout:
+        base_dir = run_dir if run_dir else os.getcwd()
+        stdout_fh = None
+        stderr_fh = None
+
+        try:
+            if stdout_file:
+                stdout_path = os.path.join(base_dir, stdout_file)
+                os.makedirs(os.path.dirname(stdout_path) or ".", exist_ok=True)
+                stdout_fh = open(stdout_path, "w")
+                stdout_target = stdout_fh
+            elif self._return_stdout:
+                stdout_target = asyncio.subprocess.PIPE
+            else:
+                stdout_target = asyncio.subprocess.DEVNULL
+
+            if stderr_file:
+                stderr_path = os.path.join(base_dir, stderr_file)
+                os.makedirs(os.path.dirname(stderr_path) or ".", exist_ok=True)
+                stderr_fh = open(stderr_path, "w")
+                stderr_target = stderr_fh
+            elif self._return_stdout:
+                stderr_target = asyncio.subprocess.PIPE
+            else:
+                stderr_target = asyncio.subprocess.DEVNULL
+
             try:
                 p = await asyncio.create_subprocess_exec(
                     program,
                     *args,
                     env=merged_env,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
+                    stdout=stdout_target,
+                    stderr=stderr_target,
                     start_new_session=True,
                     cwd=run_dir,
                 )
             except Exception as e:
                 self.logger.error(f"Submitting task {task_id} failed with error: {e}")
                 raise e
-        else:
-            try:
-                p = await asyncio.create_subprocess_exec(
-                    program,
-                    *args,
-                    env=merged_env,
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                    start_new_session=True,
-                    cwd=run_dir,
-                )
-            except Exception as e:
-                self.logger.error(f"Submitting task {task_id} failed error: {e}")
 
-        self._processes[task_id] = p
+            self._processes[task_id] = p
 
-        try:
             std_out, std_err = await p.communicate()
 
-            out_str = std_out.decode() if std_out else ""
-            err_str = std_err.decode() if std_err else ""
+            if stdout_file and self._return_stdout:
+                stdout_fh.flush()
+                with open(stdout_path, "r") as f:
+                    out_str = f.read()
+            else:
+                out_str = std_out.decode() if std_out else ""
+
+            if stderr_file and self._return_stdout:
+                stderr_fh.flush()
+                with open(stderr_path, "r") as f:
+                    err_str = f.read()
+            else:
+                err_str = std_err.decode() if std_err else ""
 
             if p.returncode != 0:
                 self.logger.error(
@@ -358,6 +384,10 @@ class AsyncMPIExecutor(Executor):
             return out_str + "," + err_str
 
         finally:
+            if stdout_fh:
+                stdout_fh.close()
+            if stderr_fh:
+                stderr_fh.close()
             if task_id in self._processes:
                 del self._processes[task_id]
 

--- a/ensemble_launcher/orchestrator/async_worker.py
+++ b/ensemble_launcher/orchestrator/async_worker.py
@@ -801,6 +801,8 @@ class AsyncWorker(Node):
                             task_kwargs=task.kwargs,
                             env=task.env,
                             run_dir=task.run_dir,
+                            stdout_file=task.stdout_file,
+                            stderr_file=task.stderr_file,
                         )
                         self._task_id_to_executor[task_id] = task.executor_name
                     else:
@@ -819,6 +821,8 @@ class AsyncWorker(Node):
                         task_kwargs=task.kwargs,
                         env=task.env,
                         run_dir=task.run_dir,
+                        stdout_file=task.stdout_file,
+                        stderr_file=task.stderr_file,
                     )
                     self._task_id_to_executor[task_id] = self._default_executor_name
 

--- a/ensemble_launcher/tests/test_async_worker.py
+++ b/ensemble_launcher/tests/test_async_worker.py
@@ -118,6 +118,56 @@ async def test_async_mpi_worker(task_executor="async_mpi"):
 
 
 @pytest.mark.asyncio
+async def test_async_mpi_worker_stdout_file(tmp_path, task_executor="async_mpi"):
+    tasks = {}
+    for i in range(2):
+        tasks[f"task-{i}"] = Task(
+            task_id=f"task-{i}",
+            nnodes=1,
+            ppn=1,
+            executable=f"echo Hello from task task-{i}",
+            args=(),
+            run_dir=str(tmp_path),
+            stdout_file=f"task-{i}.stdout",
+            stderr_file=f"task-{i}.stderr",
+        )
+
+    nodes = [socket.gethostname()]
+    sys_info = NodeResourceCount.from_config(SystemConfig(name="local"))
+    job_resource = JobResource(resources=[sys_info], nodes=nodes)
+
+    w = AsyncWorker(
+        "test",
+        LauncherConfig(
+            task_executor_name=task_executor,
+            comm_name="async_zmq",
+            report_interval=0.5,
+            mpi_config=MPIConfig(processes_per_node_flag=None),
+            log_level=logging.INFO,
+            return_stdout=True,
+        ),
+        job_resource,
+        tasks,
+    )
+
+    res = await w.run()
+    results = {}
+    for r in res.data:
+        results[r.task_id] = r.data
+
+    assert len(results) == 2
+
+    for i in range(2):
+        stdout_path = tmp_path / f"task-{i}.stdout"
+        assert stdout_path.exists(), f"stdout file not found: {stdout_path}"
+        content = stdout_path.read_text()
+        assert f"Hello from task task-{i}" in content
+
+        stderr_path = tmp_path / f"task-{i}.stderr"
+        assert stderr_path.exists(), f"stderr file not found: {stderr_path}"
+
+
+@pytest.mark.asyncio
 async def test_async_mpi_pool_worker(task_executor="async_mpi_processpool"):
     tasks = {}
     for i in range(12):


### PR DESCRIPTION
Allow tasks to specify stdout_file and stderr_file (relative to run_dir) so subprocess output is written directly to files instead of only being piped through memory.