### PR TITLE
Give each LLM instance in call_llm its own TMPDIR, not VLLM_CACHE_ROOT

### DIFF
--- a/ensemble_launcher/helper_functions.py
+++ b/ensemble_launcher/helper_functions.py
@@ -1,6 +1,5 @@
 import os
 import socket
-from typing import Dict, List, Optional, Any
 from ensemble_launcher.comm import Result
 import json
 from subprocess import check_output, DEVNULL
@@ -36,7 +35,7 @@ def str_to_num(s: str) -> int | float:
             raise ValueError("GPU mask needs to take ints or floats as the GPU IDs.") from None
 
 
-def get_gpus() -> list[int | float]:
+def get_gpus() -> tuple[list[int | float], str]:
     """Get the list of GPUs available on the system node
     """
     # NVIDIA
@@ -49,7 +48,7 @@ def get_gpus() -> list[int | float]:
         else:
             output = check_output(["nvidia-smi", "-L"], stderr=DEVNULL).decode("utf-8").splitlines()
             gpus = list(range(len(output)))
-        return gpus
+        return gpus, "nvidia"
     except:
         pass
 
@@ -75,11 +74,11 @@ def get_gpus() -> list[int | float]:
                 elif hierarchy_mode == "COMPOSITE":
                     gpus.append(i + 0.0)
                     gpus.append(i + 0.1)
-        return gpus
+        return gpus, "intel"
     except:
         pass
 
-    return []
+    return [], ""
 
 
 def write_results_to_json(results: Result, fname: str = "./results.json"):

--- a/ensemble_launcher/inference/utils.py
+++ b/ensemble_launcher/inference/utils.py
@@ -193,8 +193,8 @@ def call_llm(
     os.environ["MASTER_PORT"] = str(_actor_port) if _actor_port is not None else "0"
     os.environ["VLLM_PORT"] = str(_actor_port) if _actor_port is not None else "0"
     os.environ["VLLM_HOST_IP"] = "localhost"
-    os.environ["VLLM_CACHE_ROOT"] = f"/tmp/vllm_cache_{uuid.uuid4().hex[:6]}"
-    os.makedirs(os.environ["VLLM_CACHE_ROOT"])
+    os.environ["TMPDIR"] = f"/tmp/vllm_cache_{uuid.uuid4().hex[:6]}"
+    os.makedirs(os.environ["TMPDIR"], exist_ok=True)
     build_model_cache()
 
     from vllm import LLM, SamplingParams

--- a/ensemble_launcher/inference/utils.py
+++ b/ensemble_launcher/inference/utils.py
@@ -73,7 +73,20 @@ def _build_model_cache(logger: Logger = None) -> int:
 
     cache_root = os.environ.get("VLLM_CACHE_ROOT")
     if not cache_root:
-        return EnvironmentError("VLLM_CACHE_ROOT must be set")
+        cache_root = f"/tmp/vllm_cache_{uuid.uuid4().hex[:6]}"
+        os.environ["VLLM_CACHE_ROOT"] = cache_root
+        os.makedirs(cache_root, exist_ok=True)
+        if logger is not None:
+            logger.info(f"VLLM_CACHE_ROOT not set; created {cache_root}")
+
+    modelinfo_dir = os.path.join(cache_root, "modelinfo")
+    if os.path.isdir(modelinfo_dir):
+        if logger is not None:
+            logger.info(
+                f"Found existing modelinfo cache at {modelinfo_dir}; "
+                "skipping build"
+            )
+        return 0
 
     if logger is not None:
         logger.info(f"Using VLLM_CACHE_ROOT={cache_root}")

--- a/ensemble_launcher/inference/utils.py
+++ b/ensemble_launcher/inference/utils.py
@@ -171,21 +171,26 @@ def call_llm(
     model: str,
     model_path: str,
     prompts: List,
-    llm_kwargs: Dict[str, Any] = {
+    llm_kwargs: Optional[Dict[str, Any]] = None,
+    sampling_kwargs: Optional[Dict[str, Any]] = None,
+):
+    start = perf_counter()
+
+    default_llm_kwargs = {
         "tensor_parallel_size": 1,
         "max_model_len": 2048,
         "enforce_eager": True,
         "trust_remote_code": True,
-        "dtype": "bloaft16",
+        "dtype": "bfloat16",
         "gpu_memory_utilization": 0.90,
-        "max_num_seqs": 1, # batch size
-    },
-    sampling_kwargs: Dict[str, Any] = {
-        "temperature": 0.0, 
+        "max_num_seqs": 1,
+    }
+    default_sampling_kwargs = {
+        "temperature": 0.0,
         "max_tokens": 1024,
-    },
-):
-    start = perf_counter()
+    }
+    llm_kwargs = {**default_llm_kwargs, **(llm_kwargs or {})}
+    sampling_kwargs = {**default_sampling_kwargs, **(sampling_kwargs or {})}
 
     _actor_port = 10000 + (os.getpid() % 100) * 200
     _actor_port = find_free_port((_actor_port, _actor_port + 200), "localhost")


### PR DESCRIPTION
Some other changes in this PR:

* Change how the default parameters for the vllm engine and sampling config are defined, so the user just needs to pass what is to be changed from the defaults. 
* Change how call_llm deals with VLLM_CACHE_ROOT. If modelinfo exists in it, it skips building it. If it doesn't exist, it creates it with unique name and populates it. 
* Return GPU type from get_gpus() utility so EL can detect what hardware it's running on.